### PR TITLE
Expose raart-w and raart-h to users

### DIFF
--- a/draw.rkt
+++ b/draw.rkt
@@ -335,6 +335,8 @@
 (provide
  (contract-out
   [raart? (-> any/c boolean?)]
+  [raart-w (-> raart? integer?)]
+  [raart-h (-> raart? integer?)]
   [draw
    (-> buffer? raart?
        void?)]


### PR DESCRIPTION
This is useful for user-defined raart combinators.